### PR TITLE
Release Candidate 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ An implementation of an Achievement System in Laravel, inspired by Laravel's Not
 4. [Unlocking Achievements](#unlocking)
 5. [Adding Progress](#progress)
 6. [Retrieving Achievements](#retrieving)
-7. [License](#license)
+7. [Event Listeners](#listening)
+8. [License](#license)
 
 
 ## <a name="requirements"></a> Requirements
@@ -78,7 +79,7 @@ class UserMadeAPost extends Achievement
 }
 ```
 
-## Unlocking Achievements <a name="unlocking"></a>
+## <a name="unlocking"></a> Unlocking Achievements 
 Achievements can be unlocked by using the `Achiever` trait.
 
 ```php
@@ -105,7 +106,7 @@ $user->unlock(new UserMadeAPost());
 Remember that you're not restricted to the `User` class. You may add the `Achiever` trait to any entity that could
 unlock Achievements.
 
-## Adding Progress
+## <a name="progress"></a> Adding Progress
 
 Instead of directly unlocking an achievement, you can add a progress to it. For example, you may have an achievement 
 `UserMade10Posts` and you want to keep track of how the user is progressing on this Achievement.
@@ -167,7 +168,7 @@ $user->setProgress(new Have100GoldOnTheBag(), $user->amountOfGoldOnTheBag);
 
 Once an Achievement reach the defined amount of points, it will be automatically unlocked.
 
-## Retrieving Achievements <a name="retrieving"></a>
+## <a name="retrieving"></a> Retrieving Achievements
 The `Achiever` trait also adds a convenient relationship to the entity implementing it: `achievements()`. You can use it
 to retrieve progress for all achievements the entity has interacted with. Since `achievements()` is a relationship, you
 can use it as a QueryBuilder to filter data even further.
@@ -185,6 +186,60 @@ $details = $user->achievementStatus(new UserMade10Posts());
 
 There are also two additional helpers on the `Achiever` trait: `inProgressAchievements()` and `unlockedAchievements()`.
 
-## License <a name="license"></a>
+## <a name="listening"></a> Event Listeners
+
+### Listening to all Achievements
+Laravel Achievements provides two events that can be listened to in order to provide "Achievement Unlocked" messages or similar. Both events receive the instance of `AchievementProgress` that triggered them. 
+
+The `Gstt\Achievements\Event\Progress` event triggers whenever an Achiever makes progress, but doesn't unlock an Achievement. The `Gstt\Achievements\Event\Unlocked` event triggers whenever an Achiever actually unlocks an achievement.
+ 
+Details on how to listen to those events are explained on [Laravel's Event documentation](https://laravel.com/docs/5.3/events).
+
+### Listening to specific Achievements
+
+The event listeners mentioned above triggers for all Achievements. If you would like to add an event listener for only a specific Achievement, you can do so by implementing the methods `whenUnlocked` or `whenProgress` on the `Achievement` class.
+
+```php
+<?php
+
+namespace App\Achievements;
+
+use Gstt\Achievements\Achievement;
+
+class UserMade50Posts extends Achievement
+{
+    /*
+     * The achievement name
+     */
+    public $name = "50 Posts Created";
+
+    /*
+     * A small description for the achievement
+     */
+    public $description = "Wow! You have already created 50 posts!";
+    
+    /*
+     * The amount of "points" this user need to obtain in order to complete this achievement
+     */
+    public $points = 50;
+    
+    /*
+     * Triggers whenever an Achiever makes progress on this achievement
+    */
+    public function whenProgress($progress)
+    {
+        
+    }
+    
+    /*
+     * Triggers whenever an Achiever unlocks this achievement
+    */
+    public function whenUnlocked($progress)
+    {
+        
+    }
+}
+```
+## <a name="license"></a> License 
 
 Laravel Achievements is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ You can also search for a specific achievement using the `achievementStatus()` m
 $details = $user->achievementStatus(new UserMade10Posts());
 ```
 
-There are also two additional helpers on the `Achiever` trait: `inProgressAchievements()` and `unlockedAchievements()`.
+There are also three additional helpers on the `Achiever` trait: `lockedAchievements()`, `inProgressAchievements()` and `unlockedAchievements()`.
 
 ## <a name="listening"></a> Event Listeners
 

--- a/src/Achievement.php
+++ b/src/Achievement.php
@@ -2,6 +2,8 @@
 
 namespace Gstt\Achievements;
 
+use Gstt\Achievements\Event\Unlocked as UnlockedEvent;
+use Gstt\Achievements\Event\Progress as ProgressEvent;
 use Gstt\Achievements\Model\AchievementDetails;
 use Gstt\Achievements\Model\AchievementProgress;
 use Illuminate\Database\Eloquent\Builder;
@@ -55,7 +57,13 @@ abstract class Achievement
         return static::class;
     }
 
-    public function getPoints(){
+    /**
+     * Gets the amount of points needed to unlock the achievement.
+     *
+     * @return int
+     */
+    public function getPoints()
+    {
         return $this->points;
     }
 
@@ -90,10 +98,10 @@ abstract class Achievement
      * @param mixed $achiever The entity that will add progress to this achievement
      * @param int   $points   The amount of points to be added to this achievement
      */
-    public function addProgressToAchiever($achiever, $points)
+    public function addProgressToAchiever($achiever, $points = 1)
     {
         $progress = $this->getOrCreateProgressForAchiever($achiever);
-        if(!$progress->isUnlocked()) {
+        if (!$progress->isUnlocked()) {
             $progress->points = $progress->points + $points;
             $progress->save();
         }
@@ -109,7 +117,7 @@ abstract class Achievement
     {
         $progress = $this->getOrCreateProgressForAchiever($achiever);
 
-        if(!$progress->isUnlocked()){
+        if (!$progress->isUnlocked()) {
             $progress->points = $points;
             $progress->save();
         }
@@ -143,10 +151,41 @@ abstract class Achievement
 
     /**
      * Will be called when the achievement is unlocked.
+     *
      * @param $progress
      */
     public function whenUnlocked($progress)
     {
+    }
 
+    /**
+     * Will be called when progress is made on the achievement.
+     *
+     * @param $progress
+     */
+    public function whenProgress($progress)
+    {
+    }
+
+    /**
+     * Triggers the AchievementUnlocked Event.
+     *
+     * @param $progress
+     */
+    public function triggerUnlocked($progress)
+    {
+        event(new UnlockedEvent($progress));
+        $this->whenUnlocked($progress);
+    }
+
+    /**
+     * Triggers the AchievementProgress Event.
+     *
+     * @param $progress
+     */
+    public function triggerProgress($progress)
+    {
+        event(new ProgressEvent($progress));
+        $this->whenProgress($progress);
     }
 }

--- a/src/AchievementsServiceProvider.php
+++ b/src/AchievementsServiceProvider.php
@@ -21,6 +21,10 @@ class AchievementsServiceProvider extends ServiceProvider
         $this->app['Gstt\Achievements\Achievement'] = function ($app) {
             return $app['gstt.achievements.achievement'];
         };
+        $this->publishes([
+            __DIR__.'/config/achievements.php' => config_path('achievements.php'),
+        ]);
+        $this->mergeConfigFrom(__DIR__.'/config/achievements.php', 'achievements');
     }
 
     /**

--- a/src/EntityRelationsAchievements.php
+++ b/src/EntityRelationsAchievements.php
@@ -11,6 +11,7 @@ namespace Gstt\Achievements;
 use Gstt\Achievements\Model\AchievementDetails;
 use Gstt\Achievements\Model\AchievementProgress;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 
 trait EntityRelationsAchievements
 {
@@ -21,6 +22,9 @@ trait EntityRelationsAchievements
      */
     public function achievements()
     {
+        if (config('achievements.locked_sync')) {
+            $this->syncAchievements();
+        }
         return $this->morphMany(AchievementProgress::class, 'achiever')
             ->orderBy('created_at', 'desc');
     }
@@ -43,7 +47,7 @@ trait EntityRelationsAchievements
     public function hasUnlocked(Achievement $achievement)
     {
         $status = $this->achievementStatus($achievement);
-        if(is_null($status) || is_null($status->unlocked_at)){
+        if (is_null($status) || is_null($status->unlocked_at)) {
             return false;
         }
         return true;
@@ -52,20 +56,67 @@ trait EntityRelationsAchievements
     /**
      * Get the entity's achievements in progress.
      *
-     * @return Builder
+     * @return Collection
      */
     public function inProgressAchievements()
     {
-        return $this->achievements()->whereNull('unlocked_at')->get();
+        return $this->achievements()->whereNull('unlocked_at')->where('points', '>', 0)->get();
     }
 
     /**
      * Get the entity's unlocked achievements.
      *
-     * @return Builder
+     * @return Collection
      */
     public function unlockedAchievements()
     {
         return $this->achievements()->whereNotNull('unlocked_at')->get();
+    }
+
+    /**
+     * Get the entity's locked achievements.
+     */
+    public function lockedAchievements()
+    {
+        if (config('achievements.locked_sync')) {
+            // Relationships should be synced. Just return relationship data.
+            return $this->achievements()->whereNull('unlocked_at')->get();
+        } else {
+            // Query all unsynced
+            $unsynced = AchievementDetails::getUnsyncedByAchiever($this)->get();
+            $self = $this;
+            $unsynced = $unsynced->map(function ($el) use ($self) {
+                $progress = new AchievementProgress();
+                $progress->details()->associate($el);
+                $progress->achiever()->associate($this);
+                $progress->points = 0;
+                $progress->created_at = null;
+                $progress->updated_at = null;
+                return $progress;
+            });
+
+            // Merge with progressed, but not yet unlocked
+            $lockedProgressed = $this->achievements()->whereNull('unlocked_at')->get();
+            $locked = $lockedProgressed->merge($unsynced);
+
+            return $locked;
+        }
+    }
+
+    /**
+     * Syncs achievement data.
+     */
+    public function syncAchievements()
+    {
+        /** @var Collection $locked */
+        $locked = AchievementDetails::getUnsyncedByAchiever($this);
+        $self = $this;
+        $locked->each(function ($el) use ($self) {
+            $progress = new AchievementProgress();
+            $progress->details()->associate($el);
+            $progress->achiever()->associate($this);
+            $progress->points = 0;
+            $progress->save();
+        });
     }
 }

--- a/src/Event/Progress.php
+++ b/src/Event/Progress.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Gstt\Achievements\Event;
+
+use Gstt\Achievements\Model\AchievementProgress;
+use Illuminate\Queue\SerializesModels;
+
+class Progress
+{
+    use SerializesModels;
+
+    public $progress;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  AchievementProgress $progress
+     */
+    public function __construct(AchievementProgress $progress)
+    {
+        $this->progress = $progress;
+    }
+}

--- a/src/Event/Unlocked.php
+++ b/src/Event/Unlocked.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Gstt\Achievements\Event;
+
+use Gstt\Achievements\Model\AchievementProgress;
+use Illuminate\Queue\SerializesModels;
+
+class Unlocked
+{
+    use SerializesModels;
+
+    public $progress;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  AchievementProgress $progress
+     */
+    public function __construct(AchievementProgress $progress)
+    {
+        $this->progress = $progress;
+    }
+}

--- a/src/Model/AchievementDetails.php
+++ b/src/Model/AchievementDetails.php
@@ -45,4 +45,21 @@ class AchievementDetails extends Model
     {
         return new $this->class_name();
     }
+
+    /**
+     * Gets all AchievementDetails that have no correspondence on the Progress table.
+     *
+     * @param mixed $achiever
+     */
+    public static function getUnsyncedByAchiever($achiever)
+    {
+        $achievements = AchievementProgress::where('achiever_type', get_class($achiever))
+                                           ->where('achiever_id', $achiever->id)->get();
+        $synced_ids = $achievements->map(function ($el) {
+            return $el->achievement_id;
+        })->toArray();
+
+        return self::whereNotIn('id', $synced_ids);
+    }
+
 }

--- a/src/Model/AchievementProgress.php
+++ b/src/Model/AchievementProgress.php
@@ -111,12 +111,15 @@ class AchievementProgress extends Model
 
         $result = parent::save($options);
 
-        if ($recently_unlocked) {
-            // Gets the achievement class for this progress
-            $class = $this->details->getClass();
+        // Gets the achievement class for this progress
+        $class = $this->details->getClass();
 
+        if ($recently_unlocked) {
             // Runs the callback set to run when the achievement is unlocked.
-            $class->whenUnlocked($this);
+            $class->triggerUnlocked($this);
+        } elseif ($this->points >= 0) {
+            // Runs the callback set to run when progress has been made on the achievement.
+            $class->triggerProgress($this);
         }
 
         return $result;

--- a/src/config/achievements.php
+++ b/src/config/achievements.php
@@ -1,0 +1,29 @@
+<?php
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Locked achievement sync
+    |--------------------------------------------------------------------------
+    |
+    | Controls the behavior of how locked achievements will be handled.
+    |
+    | Achievements are only stored on the achievement_progress table whenever
+    | they are made progress or unlocked. Therefore, by default there is no
+    | "locked achievement" storage.
+    |
+    | When set to FALSE, this will not change how the relationship works.
+    | achievements() on the Achiever trait WILL NOT RETURN LOCKED ACHIEVEMENTS,
+    | only returning records on the achievement_progress table. The locked()
+    | method will act as a simple query fetching all records that exist in
+    | achievement_details and do not have equivalent records on
+    | achievement_progress.
+    |
+    | When set to TRUE, any calls to the achievements() relationship will first
+    | fetch locked achievements and then add them to the achievement_progress
+    | table with progress 0. Therefore, the achievements() relationship WILL
+    | RETURN LOCKED ACHIEVEMENTS, and the locked() method will act as a derived
+    | query from achievements().
+    |
+    */
+    'locked_sync' => true
+];

--- a/tests/DBTestCase.php
+++ b/tests/DBTestCase.php
@@ -30,7 +30,7 @@ class DBTestCase extends TestCase
     {
         parent::setUp();
 
-        $this->app['config']->set('database.default','sqlite');
+        $this->app['config']->set('database.default', 'sqlite');
         $this->app['config']->set('database.connections.sqlite.database', ':memory:');
 
         Artisan::call('migrate');


### PR DESCRIPTION
# Changelog

## Locked achievements
- Two settings for implementing locked achievements: synced or unsynced.
  - Synced achievements automatically updates all Achievements in the Achiever list, adding a record on `achievement_progress` with 0 points for all Achievements the user still didn't progressed into.
    - This method overrides the previous behavior on the `achievements()` relationship, which previously only returned data for Achievements where the Achiever actually unlocked or made progress to.
    - This is the default method for new installations.
  - Unsynced achievements keep the previous behavior of the `achievements()` relationship and returns locked achievements via a DB query.
    - This method makes the `achievements()` relationship not return locked achievement data.

## Event handler
- Achievements now trigger events when an Achiever unlocks or progresses in it. These events can be listened to provide "Achievement Unlocked" notifications.
- Previous handlers `whenUnlocked` and `whenProgressed` on the `Achievement` classes are now documented and can also be added in order to trigger events specific to these Achievements.

## Documentation
- Updated documentation with the newest additions.
- Added a docs folder for further documentation on GitHub Pages.

## Extras
- `addProgressToAchiever()` now has a default value of 1 point. Previous behavior is unaltered.
- Source is now PSR-4 compatible for better readability.