### PR TITLE
Use Eloquent::getMorphClass() instead of get_class($model)

### DIFF
--- a/src/Achievement.php
+++ b/src/Achievement.php
@@ -125,7 +125,7 @@ abstract class Achievement
 
     /**
      * Gets the achiever's progress data for this achievement, or creates a new one if not existant
-     * @param mixed|null $achiever
+     * @param \Illuminate\Database\Eloquent\Model $achiever
      *
      * @return AchievementProgress
      */

--- a/src/Achievement.php
+++ b/src/Achievement.php
@@ -131,11 +131,7 @@ abstract class Achievement
      */
     public function getOrCreateProgressForAchiever($achiever)
     {
-        if ($achiever instanceof \Illuminate\Database\Eloquent\Model) {
-            $className = $achiever->getMorphClass();
-        } else {
-            $className = get_class($achiever);
-        }
+        $className = $this->getAchieverClassName($achiever);
 
         $achievementId = $this->getModel()->id;
         $progress = AchievementProgress::where('achiever_type', $className)
@@ -152,6 +148,21 @@ abstract class Achievement
         }
 
         return $progress;
+    }
+
+    /**
+     * Gets model morph name
+     *
+     * @param \Illuminate\Database\Eloquent\Model $achiever
+     * @return string
+     */
+    protected function getAchieverClassName($achiever)
+    {
+        if ($achiever instanceof \Illuminate\Database\Eloquent\Model) {
+            return $achiever->getMorphClass();
+        }
+
+        return get_class($achiever);
     }
 
     /**

--- a/src/Achievement.php
+++ b/src/Achievement.php
@@ -131,7 +131,12 @@ abstract class Achievement
      */
     public function getOrCreateProgressForAchiever($achiever)
     {
-        $className = get_class($achiever);
+        if ($achiever instanceof \Illuminate\Database\Eloquent\Model) {
+            $className = $achiever->getMorphClass();
+        } else {
+            $className = get_class($achiever);
+        }
+
         $achievementId = $this->getModel()->id;
         $progress = AchievementProgress::where('achiever_type', $className)
                                        ->where('achievement_id', $achievementId)

--- a/src/Model/AchievementDetails.php
+++ b/src/Model/AchievementDetails.php
@@ -49,17 +49,34 @@ class AchievementDetails extends Model
     /**
      * Gets all AchievementDetails that have no correspondence on the Progress table.
      *
-     * @param mixed $achiever
+     * @param \Illuminate\Database\Eloquent\Model $achiever
      */
     public static function getUnsyncedByAchiever($achiever)
     {
-        $achievements = AchievementProgress::where('achiever_type', get_class($achiever))
+        $className = (new static)->getAchieverClassName($achiever);
+
+        $achievements = AchievementProgress::where('achiever_type', $className)
                                            ->where('achiever_id', $achiever->id)->get();
         $synced_ids = $achievements->map(function ($el) {
             return $el->achievement_id;
         })->toArray();
 
         return self::whereNotIn('id', $synced_ids);
+    }
+
+    /**
+     * Gets model morph name
+     *
+     * @param \Illuminate\Database\Eloquent\Model $achiever
+     * @return string
+     */
+    protected function getAchieverClassName($achiever)
+    {
+        if ($achiever instanceof \Illuminate\Database\Eloquent\Model) {
+            return $achiever->getMorphClass();
+        }
+
+        return get_class($achiever);
     }
 
 }


### PR DESCRIPTION
https://laravel.com/docs/5.2/eloquent-relationships#polymorphic-relations

```php
use Illuminate\Database\Eloquent\Relations\Relation;
Relation::morphMap([
    'users' => 'App\User',
]);
```

When polymorphic relation associates model instance it uses model method `getMorphClass`
https://github.com/laravel/framework/blob/5.6/src/Illuminate/Database/Eloquent/Relations/MorphTo.php#L206

```php

get_class($achiever) != $achiever->getMorphClass();
// App\User != 'users'
```